### PR TITLE
Changed ip from hard-coded to default localhost one

### DIFF
--- a/etc/schema-registry/schema-registry.properties
+++ b/etc/schema-registry/schema-registry.properties
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-listeners=http://10.91.31.169:8081
-kafkastore.connection.url=10.91.31.169:2181
+listeners=http://localhost:8081
+kafkastore.connection.url=localhost:2181
 kafkastore.topic=_schemas
 debug=true


### PR DESCRIPTION
Schema registry can't connect to a zookeeper if ip is hard coded in schema-registry.properties